### PR TITLE
made no flatbutton the default

### DIFF
--- a/mxwelcome.ui
+++ b/mxwelcome.ui
@@ -120,10 +120,7 @@
          </size>
         </property>
         <property name="autoDefault">
-         <bool>true</bool>
-        </property>
-        <property name="default">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="flat">
          <bool>true</bool>

--- a/mxwelcome.ui
+++ b/mxwelcome.ui
@@ -623,7 +623,7 @@
         <string>About...</string>
        </property>
        <property name="icon">
-        <iconset theme="help-about">
+        <iconset theme="gtk-about">
          <normaloff>.</normaloff>.</iconset>
        </property>
        <property name="shortcut">


### PR DESCRIPTION
Designating a flatbutton as "Default" gave the button a strange double border with white dashes when users selected a dark theme. Eliminated that eventuality by making no buttons the "Default."